### PR TITLE
[Chore] 기본값 공백으로 수정 및 그라데이션 수정 (#52)

### DIFF
--- a/NaverPay/Scenes/Home/Cells/HomeEventSectionCollectionViewCell.swift
+++ b/NaverPay/Scenes/Home/Cells/HomeEventSectionCollectionViewCell.swift
@@ -22,19 +22,18 @@ final class HomeEventSectionCollectionViewCell: UICollectionViewCell {
     
     private let benefitLabel: NPLabel = {
         let label = NPLabel(font: .font(.detail_regular_14), color: .bg_white.withAlphaComponent(0.8))
-        label.text = "매일매일 더블혜택"
+        label.text = ""
         return label
     }()
     
     private let benefitDetailLabel: NPLabel = {
         let label = NPLabel(font: .font(.subtitle_bold_17), color: .bg_white)
-        label.text = "최대 10%"
+        label.text = ""
         return label
     }()
     
     private let logoImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = ImageLiterals.MainView.event_img_logo_touslesjours
         return imageView
     }()
     

--- a/NaverPay/Scenes/Home/Cells/HomePlaceSectionCollectionViewCell.swift
+++ b/NaverPay/Scenes/Home/Cells/HomePlaceSectionCollectionViewCell.swift
@@ -25,13 +25,13 @@ final class HomePlaceSectionCollectionViewCell: UICollectionViewCell {
     
     private let storeNameLabel: NPLabel = {
         let label = NPLabel(font: .font(.detail_regular_14), color: .grayscale_gray5)
-        label.text = "CU 건대점"
+        label.text = ""
         return label
     }()
     
     private let descriptionLabel: NPLabel = {
         let label = NPLabel(font: .font(.body_smbold_16), color: .bg_white)
-        label.text = "네플멤 회원은 최대 10%"
+        label.text = ""
         return label
     }()
     
@@ -43,7 +43,6 @@ final class HomePlaceSectionCollectionViewCell: UICollectionViewCell {
     
     private let logoImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = ImageLiterals.MainView.logoCuDummy
         return imageView
     }()
     

--- a/NaverPay/Scenes/Home/Cells/HomePointSectionCollectionViewCell.swift
+++ b/NaverPay/Scenes/Home/Cells/HomePointSectionCollectionViewCell.swift
@@ -24,7 +24,6 @@ final class HomePointSectionCollectionViewCell: UICollectionViewCell {
     
     private let cardImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = ImageLiterals.MainView.imgCard2
         return imageView
     }()
     

--- a/NaverPay/Scenes/Home/Cells/HomeRecentPaymentsSectionCollectionViewCell.swift
+++ b/NaverPay/Scenes/Home/Cells/HomeRecentPaymentsSectionCollectionViewCell.swift
@@ -24,19 +24,18 @@ final class HomeRecentPaymentsSectionCollectionViewCell: UICollectionViewCell {
     
     private let paidAmountLabel: NPLabel = {
         let label = NPLabel(font: .font(.head_bold_20), color: .bg_black)
-        label.text = "-25,000원"
+        label.text = ""
         return label
     }()
     
     private let storeNameLabel: NPLabel = {
         let label = NPLabel(font: .font(.body_smbold_16), color: .bg_black)
-        label.text = "GS25 건대점"
+        label.text = ""
         return label
     }()
     
     private let logoImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = ImageLiterals.MainView.logoGs25
         imageView.contentMode = .scaleAspectFill
         return imageView
     }()

--- a/NaverPay/Scenes/Home/ViewControllers/HomeViewController.swift
+++ b/NaverPay/Scenes/Home/ViewControllers/HomeViewController.swift
@@ -189,7 +189,7 @@ extension HomeViewController: UICollectionViewDelegate {
                 homeCardData[index].isSelected = false
             }
             homeCardData[indexPath.item].isSelected = true
-            collectionView.reloadSections(IndexSet(integer: 1))
+            collectionView.reloadData()
         }
     }
 }

--- a/NaverPay/Scenes/Home/Views/HomePlaceSectionFooterView.swift
+++ b/NaverPay/Scenes/Home/Views/HomePlaceSectionFooterView.swift
@@ -50,14 +50,13 @@ final class HomePlaceSectionFooterView: UICollectionReusableView {
         }
         icMapImageView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(18.5)
-            $0.bottom.equalToSuperview().offset(-16.5)
-            $0.trailing.equalTo(mapLabel.snp.leading).inset(-5)
-            $0.width.equalTo(17)
+            $0.leading.equalToSuperview().inset(120)
+            $0.size.equalTo(17)
         }
         mapLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(15)
             $0.bottom.equalToSuperview().offset(-13)
-            $0.trailing.equalToSuperview().inset(118)
+            $0.leading.equalTo(icMapImageView.snp.trailing).inset(-5)
             $0.width.equalTo(74)
         }
     }

--- a/NaverPay/Scenes/Home/Views/HomePointSectionBackgroundView.swift
+++ b/NaverPay/Scenes/Home/Views/HomePointSectionBackgroundView.swift
@@ -26,29 +26,24 @@ final class HomePointSectionBackgroundView: UICollectionReusableView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    //그라데이션을 구현
+ 
     private func setGradientBackground() {
         let gradientLayer = CAGradientLayer()
-        backgroundView.layer.cornerRadius = 10
-        backgroundView.clipsToBounds = true
-        
-        self.layer.cornerRadius = 10
-        self.clipsToBounds = true
-        
-        
+
         gradientLayer.colors = [
-            UIColor(red: 0.02, green: 0.67, blue: 0.40, alpha: 1.0).cgColor, // #06AA65
-            UIColor(red: 0.03, green: 0.67, blue: 0.55, alpha: 1.0).cgColor  // #07AA8C
+            UIColor(red: 0.03, green: 0.67, blue: 0.55, alpha: 1.00).cgColor,  // #07AA8C
+            UIColor(red: 0.02, green: 0.67, blue: 0.40, alpha: 1.00).cgColor  // #06AA65
         ]
-        
+
         let angle = 113.0 * .pi / 180.0
         let x = cos(angle)
         let y = sin(angle)
-        
-        gradientLayer.startPoint = CGPoint(x: CGFloat(x), y: CGFloat(y))
+
+        gradientLayer.startPoint = CGPoint(x: 1.0, y: 0.0)
         gradientLayer.endPoint = CGPoint(x: 0.0, y: 1.0)
         gradientLayer.frame = bounds
-        
+        gradientLayer.locations = [0.0232, 0.9345]
+
         layer.insertSublayer(gradientLayer, at: 0)
     }
     

--- a/NaverPay/Scenes/Home/Views/HomePointSectionHeaderView.swift
+++ b/NaverPay/Scenes/Home/Views/HomePointSectionHeaderView.swift
@@ -69,7 +69,7 @@ final class HomePointSectionHeaderView: UICollectionReusableView {
     
     private let depositDetailLabel: NPLabel = {
         let label = NPLabel(font: .font(.number_bold_27), color: .bg_white)
-        label.text = "15,000"
+        label.text = ""
         return label
     }()
     

--- a/NaverPay/Scenes/Home/Views/HomePointSectionHeaderView.swift
+++ b/NaverPay/Scenes/Home/Views/HomePointSectionHeaderView.swift
@@ -44,7 +44,6 @@ final class HomePointSectionHeaderView: UICollectionReusableView {
     private let titleLabel: NPLabel = {
         let label = NPLabel(font: .font(.head_bold_20), color: .bg_white)
         label.text = "네이버 포인트"
-        label.layer.opacity = 0.6
         return label
     }()
     
@@ -153,23 +152,23 @@ final class HomePointSectionHeaderView: UICollectionReusableView {
         }
     }
     
-    //그라데이션 컬러 설정 main_home_cardline 색상
     private func setGradientBackground() {
         let gradientLayer = CAGradientLayer()
-        
+
         gradientLayer.colors = [
-            UIColor(red: 0.02, green: 0.67, blue: 0.40, alpha: 1.0).cgColor, // #06AA65
-            UIColor(red: 0.03, green: 0.67, blue: 0.55, alpha: 1.0).cgColor  // #07AA8C
+            UIColor(red: 0.03, green: 0.67, blue: 0.55, alpha: 1.00).cgColor,  // #07AA8C
+            UIColor(red: 0.02, green: 0.67, blue: 0.40, alpha: 1.00).cgColor  // #06AA65
         ]
-        
+
         let angle = 113.0 * .pi / 180.0
         let x = cos(angle)
         let y = sin(angle)
-        
-        gradientLayer.startPoint = CGPoint(x: CGFloat(x), y: CGFloat(y))
+
+        gradientLayer.startPoint = CGPoint(x: 1.0, y: 0.0)
         gradientLayer.endPoint = CGPoint(x: 0.0, y: 1.0)
         gradientLayer.frame = bounds
-        
+        gradientLayer.locations = [0.0232, 0.9345]
+
         layer.insertSublayer(gradientLayer, at: 0)
     }
     

--- a/NaverPay/Scenes/Home/Views/HomeRecentPaymentsSectionHeaderView.swift
+++ b/NaverPay/Scenes/Home/Views/HomeRecentPaymentsSectionHeaderView.swift
@@ -31,7 +31,7 @@ final class HomeRecentPaymentsSectionHeaderView: UICollectionReusableView {
     
     private let dateLabel: NPLabel = {
         let label = NPLabel(font: .font(.body_smbold_16), color: .main_lightgreen)
-        label.text = "11.16"
+        label.text = ""
         return label
     }()
     


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- #52

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
1. 데이터가 들어갈 곳의 기본값을 공백으로 변경하였습니다.
2. 그라데이션 설정을 변경하였습니다.
```
border-radius: 10px 10px 0px 0px;
border: 1px solid var(--main_home_cardline, #3BE084);
background: linear-gradient(113deg, #06AA65 2.32%, #07AA8C 93.45%);
```

다음과 같은 설정의 백그라운드 색상을 구현하였습니다.

```swift
private func setGradientBackground() {
        let gradientLayer = CAGradientLayer()

        gradientLayer.colors = [
            UIColor(red: 0.03, green: 0.67, blue: 0.55, alpha: 1.00).cgColor,  // #07AA8C
            UIColor(red: 0.02, green: 0.67, blue: 0.40, alpha: 1.00).cgColor  // #06AA65
        ]

        let angle = 113.0 * .pi / 180.0
        let x = cos(angle)
        let y = sin(angle)

        gradientLayer.startPoint = CGPoint(x: 1.0, y: 0.0)
        gradientLayer.endPoint = CGPoint(x: 0.0, y: 1.0)
        gradientLayer.frame = bounds
        gradientLayer.locations = [0.0232, 0.9345]

        layer.insertSublayer(gradientLayer, at: 0)
    }
 
```

        gradientLayer.startPoint = CGPoint(x: 1.0, y: 0.0)
        gradientLayer.endPoint = CGPoint(x: 0.0, y: 1.0)
        
       이 부분에 해당하는 값은 그라데이션이 퍼지는 포인트를 잡아주는 겁니다.
       저는 우상단에서 좌하단으로 대각선으로 퍼지는 그라데이션이었기에 다음과 같이 구현하였습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- UI 적으로 수정사항 있으시면 알려주세요!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/SOPT-33RD-APP-NAVERPAY/NaverPay-iOS/assets/95562494/02ec5323-874f-47da-b706-33053daa52b5" width ="250">|


## 📟 관련 이슈
- Resolved: #52
