### PR TITLE
[Feat] benefitView 토스트메세지, 에러 핸들링 (#53)

### DIFF
--- a/NaverPay.xcodeproj/project.pbxproj
+++ b/NaverPay.xcodeproj/project.pbxproj
@@ -102,6 +102,9 @@
 		F4FF80122B18D46300681C0D /* BenefitEntireSectionDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF80112B18D46300681C0D /* BenefitEntireSectionDTO.swift */; };
 		F4FF80182B18DA2700681C0D /* BenefitEntireAppData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF80172B18DA2700681C0D /* BenefitEntireAppData.swift */; };
 		F4FF801A2B1909C100681C0D /* BenefitLikeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF80192B1909C100681C0D /* BenefitLikeDTO.swift */; };
+		F4FF801D2B19A65400681C0D /* NPToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF801C2B19A65400681C0D /* NPToastView.swift */; };
+		F4FF801F2B19A67300681C0D /* NPToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF801E2B19A67300681C0D /* NPToast.swift */; };
+		F4FF80212B19A7F000681C0D /* UIWindow+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF80202B19A7F000681C0D /* UIWindow+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -189,6 +192,9 @@
 		F4FF80112B18D46300681C0D /* BenefitEntireSectionDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenefitEntireSectionDTO.swift; sourceTree = "<group>"; };
 		F4FF80172B18DA2700681C0D /* BenefitEntireAppData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BenefitEntireAppData.swift; path = Scenes/Benefit/Models/BenefitEntireAppData.swift; sourceTree = "<group>"; };
 		F4FF80192B1909C100681C0D /* BenefitLikeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenefitLikeDTO.swift; sourceTree = "<group>"; };
+		F4FF801C2B19A65400681C0D /* NPToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NPToastView.swift; sourceTree = "<group>"; };
+		F4FF801E2B19A67300681C0D /* NPToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NPToast.swift; sourceTree = "<group>"; };
+		F4FF80202B19A7F000681C0D /* UIWindow+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -337,6 +343,7 @@
 		F4DDEB252B0A597100B7BCCE /* UIComponents */ = {
 			isa = PBXGroup;
 			children = (
+				F4FF801B2B19A62300681C0D /* NPToast */,
 				F4DDEB6E2B0D1FF500B7BCCE /* NPLabel.swift */,
 				0B125CDD2B105DD20051DDEF /* FormattedString.swift */,
 				0B663D4A2B1596FC001BAC91 /* TabBarViewController.swift */,
@@ -355,6 +362,7 @@
 				F4DDEB592B0BCBEB00B7BCCE /* UITextField+.swift */,
 				F4DDEB5B2B0BCCA900B7BCCE /* UIStackView+.swift */,
 				F4FF80092B165BC000681C0D /* Codable+.swift */,
+				F4FF80202B19A7F000681C0D /* UIWindow+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -583,6 +591,15 @@
 			path = Configuration;
 			sourceTree = "<group>";
 		};
+		F4FF801B2B19A62300681C0D /* NPToast */ = {
+			isa = PBXGroup;
+			children = (
+				F4FF801C2B19A65400681C0D /* NPToastView.swift */,
+				F4FF801E2B19A67300681C0D /* NPToast.swift */,
+			);
+			path = NPToast;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -676,6 +693,7 @@
 				F4DDEB862B0FD70100B7BCCE /* BenefitCollectionEntireBenefitSectionHeaderView.swift in Sources */,
 				0B0DFB212B0D2102005F8618 /* HomeEventSectionHeaderView.swift in Sources */,
 				0B6677B52B0CD4CF00821105 /* (null) in Sources */,
+				F4FF801F2B19A67300681C0D /* NPToast.swift in Sources */,
 				0B0DFB222B0D2102005F8618 /* HomePlaceSectionHeaderView.swift in Sources */,
 				F4DDEB0A2B0A52E600B7BCCE /* AppDelegate.swift in Sources */,
 				F4DDEB632B0CDC1600B7BCCE /* BenefitCollectionViewPointCheckCell.swift in Sources */,
@@ -701,6 +719,7 @@
 				ED56A30A2B0F827B005FE6AF /* CardCollectionViewCell.swift in Sources */,
 				F4DDEB0C2B0A52E600B7BCCE /* SceneDelegate.swift in Sources */,
 				0B663D4F2B15976E001BAC91 /* BenefitHeaderView.swift in Sources */,
+				F4FF801D2B19A65400681C0D /* NPToastView.swift in Sources */,
 				ED56A30C2B0F82CD005FE6AF /* BannerCollectionViewCell.swift in Sources */,
 				ED56A3122B1103F2005FE6AF /* UserPlaceAppData.swift in Sources */,
 				0B0DFB202B0D2102005F8618 /* HomeRecentPaymentsSectionHeaderView.swift in Sources */,
@@ -708,6 +727,7 @@
 				0B6677B92B0CD61C00821105 /* (null) in Sources */,
 				0B0DFB172B0D20F3005F8618 /* HomeRecentPaymentsSectionCollectionViewCell.swift in Sources */,
 				F4DDEB8C2B10B18800B7BCCE /* BenefitCollectionadBannerFooterView.swift in Sources */,
+				F4FF80212B19A7F000681C0D /* UIWindow+.swift in Sources */,
 				0B5407252B16D0AA00806E5C /* HomeService.swift in Sources */,
 				F4FF80182B18DA2700681C0D /* BenefitEntireAppData.swift in Sources */,
 				0B6677BB2B0CD63200821105 /* (null) in Sources */,

--- a/NaverPay/Application/SceneDelegate.swift
+++ b/NaverPay/Application/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
       guard let windowScene = (scene as? UIWindowScene) else { return }
       self.window = UIWindow(windowScene: windowScene)
-      let viewController =  HomeViewController()
+//      let viewController =  HomeViewController()
       let navigationController = UINavigationController(rootViewController: TabBarViewController())
       navigationController.setNavigationBarHidden(true, animated: false)
       self.window?.rootViewController = navigationController

--- a/NaverPay/Global/Extensions/UIWindow+.swift
+++ b/NaverPay/Global/Extensions/UIWindow+.swift
@@ -1,0 +1,8 @@
+//
+//  UIWindow+.swift
+//  NaverPay
+//
+//  Created by 곽성준 on 12/1/23.
+//
+
+import Foundation

--- a/NaverPay/Global/Extensions/UIWindow+.swift
+++ b/NaverPay/Global/Extensions/UIWindow+.swift
@@ -5,4 +5,10 @@
 //  Created by 곽성준 on 12/1/23.
 //
 
-import Foundation
+import UIKit
+
+extension UIWindow {
+    public static var current: UIWindow? {
+        UIApplication.shared.windows.first(where: \.isKeyWindow)
+    }
+}

--- a/NaverPay/Global/UIComponents/NPToast/NPToast.swift
+++ b/NaverPay/Global/UIComponents/NPToast/NPToast.swift
@@ -21,7 +21,7 @@ final class LHToast {
         toastView.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(120)
             
-            $0.leading.trailing.equalToSuperview().inset(40)
+            $0.leading.trailing.equalToSuperview().inset(25)
         }
         
         window.layoutSubviews()

--- a/NaverPay/Global/UIComponents/NPToast/NPToast.swift
+++ b/NaverPay/Global/UIComponents/NPToast/NPToast.swift
@@ -1,0 +1,8 @@
+//
+//  NPToast.swift
+//  NaverPay
+//
+//  Created by 곽성준 on 12/1/23.
+//
+
+import Foundation

--- a/NaverPay/Global/UIComponents/NPToast/NPToast.swift
+++ b/NaverPay/Global/UIComponents/NPToast/NPToast.swift
@@ -9,12 +9,12 @@ import UIKit
 
 import SnapKit
 
-final class LHToast {
+final class NPToast {
     static func show (message: String, duration: TimeInterval = 1, isTabBar: Bool = true, completion: (() -> Void)? = nil) {
-        let toastView = LHToastView(message: message)
+        let toastView = NPToastView(message: message)
         guard let window = UIWindow.current else { return }
         window.subviews
-            .filter { $0 is LHToastView }
+            .filter { $0 is NPToastView }
             .forEach { $0.removeFromSuperview() }
         window.addSubview(toastView)
         

--- a/NaverPay/Global/UIComponents/NPToast/NPToast.swift
+++ b/NaverPay/Global/UIComponents/NPToast/NPToast.swift
@@ -5,4 +5,54 @@
 //  Created by 곽성준 on 12/1/23.
 //
 
-import Foundation
+import UIKit
+
+import SnapKit
+
+final class LHToast {
+    static func show (message: String, duration: TimeInterval = 1, isTabBar: Bool = true, completion: (() -> Void)? = nil) {
+        let toastView = LHToastView(message: message)
+        guard let window = UIWindow.current else { return }
+        window.subviews
+            .filter { $0 is LHToastView }
+            .forEach { $0.removeFromSuperview() }
+        window.addSubview(toastView)
+        
+        toastView.snp.makeConstraints {
+            $0.bottom.equalToSuperview().inset(120)
+            
+            $0.leading.trailing.equalToSuperview().inset(40)
+        }
+        
+        window.layoutSubviews()
+        
+        fadeIn(completion: {
+            DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+                fadeOut(completion: {
+                    completion?()
+                })
+            }
+        })
+        
+        func fadeIn(completion: (() -> Void)? = nil) {
+            toastView.alpha = 0
+            UIView.animate(withDuration: 0.5) {
+                toastView.alpha = 1
+            } completion: { _ in
+                completion?()
+            }
+            
+        }
+        
+        func fadeOut(completion: (() -> Void)? = nil) {
+            toastView.alpha = 1
+            UIView.animate(withDuration: 0.5) {
+                toastView.alpha = 0
+            } completion: { _ in
+                toastView.removeFromSuperview()
+                completion?()
+            }
+        }
+    }
+}
+

--- a/NaverPay/Global/UIComponents/NPToast/NPToastView.swift
+++ b/NaverPay/Global/UIComponents/NPToast/NPToastView.swift
@@ -5,4 +5,39 @@
 //  Created by 곽성준 on 12/1/23.
 //
 
-import Foundation
+import UIKit
+
+final class LHToastView: UIView {
+    
+    private let messageLabel = UILabel()
+    
+    init(message: String, backgroundColor: UIColor? = UIColor.grayscale_gray6 , messageColor: UIColor? = UIColor.bg_white) {
+        super.init(frame: .zero)
+        self.messageLabel.textColor = messageColor
+        self.messageLabel.text = message
+        self.backgroundColor = backgroundColor?.withAlphaComponent(0.8)
+        self.setUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension LHToastView {
+    private func setUI() {
+        self.layer.cornerRadius = 10
+        self.clipsToBounds = true
+        self.messageLabel.font = .font(.body_bold_15)
+        self.messageLabel.textAlignment = .center
+
+        self.addSubview(messageLabel)
+        self.snp.makeConstraints {
+            $0.height.equalTo(50)
+            
+        }
+        self.messageLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+    }
+}

--- a/NaverPay/Global/UIComponents/NPToast/NPToastView.swift
+++ b/NaverPay/Global/UIComponents/NPToast/NPToastView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class LHToastView: UIView {
+final class NPToastView: UIView {
     
     private let messageLabel = UILabel()
     
@@ -24,7 +24,7 @@ final class LHToastView: UIView {
     }
 }
 
-extension LHToastView {
+extension NPToastView {
     private func setUI() {
         self.layer.cornerRadius = 10
         self.clipsToBounds = true

--- a/NaverPay/Global/UIComponents/NPToast/NPToastView.swift
+++ b/NaverPay/Global/UIComponents/NPToast/NPToastView.swift
@@ -1,0 +1,8 @@
+//
+//  NPToastView.swift
+//  NaverPay
+//
+//  Created by 곽성준 on 12/1/23.
+//
+
+import Foundation

--- a/NaverPay/Network/Base/NetworkError.swift
+++ b/NaverPay/Network/Base/NetworkError.swift
@@ -11,9 +11,8 @@ import Foundation
 enum NetworkError: Error, CustomStringConvertible {
     case urlEncodingError
     case jsonDecodingError
-    case badCasting
     case fetchImageError
-    case clientError
+    case clientError(message: String)
     case serverError
     
     var description: String {
@@ -22,12 +21,10 @@ enum NetworkError: Error, CustomStringConvertible {
             return "🔒URL Encoding 에러입니다"
         case .jsonDecodingError:
             return "🔐JSON Decoding 에러입니다"
-        case .badCasting:
-            return "❌잘못된 타입 캐스팅입니다 (HTTPResponse)"
         case .fetchImageError:
             return "🌄Image URL로부터 불러오기 실패"
-        case .clientError:
-            return "📱클라이언트 에러"
+        case .clientError(let message):
+            return "📱클라이언트 에러 : \(message)"
         case .serverError:
             return "🖥️서버 에러"
         }

--- a/NaverPay/Network/Base/Serviceable.swift
+++ b/NaverPay/Network/Base/Serviceable.swift
@@ -25,6 +25,12 @@ extension Serviceable {
             throw NetworkError.jsonDecodingError
         }
 
+        
+        
+        if model.status == 400 || model.status == 401 {
+            throw NetworkError.clientError(message: model.message)
+        }
+            
         print("""
         -------------------------------------------------------------
         statusCode : \(model.status)

--- a/NaverPay/Scenes/Benefit/ViewControllers/BenefitViewController.swift
+++ b/NaverPay/Scenes/Benefit/ViewControllers/BenefitViewController.swift
@@ -37,20 +37,15 @@ final class BenefitViewController: UIViewController {
         return collectionView
     }()
     
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        getBenefitMainData()
-        getBenefitEntireData()
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         setLayout()
         setCollectionView()
         setStyle()
+        
+        getBenefitMainData()
+        getBenefitEntireData()
         
         
     }
@@ -379,10 +374,10 @@ extension BenefitViewController: ItemSelectedProtocol {
     func getButtonState(isLiked: Bool, brandId: Int) {
         if isLiked {
             postLikedBrand(brandIdNum: brandId, post: .post)
-            LHToast.show(message: "좋아요")
+            LHToast.show(message: "'나의 혜택'에 보관했어요")
         } else {
             postLikedBrand(brandIdNum: brandId, post: .delete)
-            LHToast.show(message: "싫어요")
+            LHToast.show(message: "보관을 취소했어요")
 
         }
     }

--- a/NaverPay/Scenes/Benefit/ViewControllers/BenefitViewController.swift
+++ b/NaverPay/Scenes/Benefit/ViewControllers/BenefitViewController.swift
@@ -374,15 +374,28 @@ extension BenefitViewController: ItemSelectedProtocol {
     func getButtonState(isLiked: Bool, brandId: Int) {
         if isLiked {
             postLikedBrand(brandIdNum: brandId, post: .post)
-            LHToast.show(message: "'나의 혜택'에 보관했어요")
+            NPToast.show(message: "'나의 혜택'에 보관했어요")
         } else {
             postLikedBrand(brandIdNum: brandId, post: .delete)
-            LHToast.show(message: "보관을 취소했어요")
-
+            NPToast.show(message: "보관을 취소했어요")
+            
         }
     }
 }
 
+
+extension BenefitViewController {
+    func handlingError(_ error: NetworkError) {
+        switch error {
+        case .clientError(let message):
+            NPToast.show(message: "\(message)")
+        default:
+            NPToast.show(message: error.description)
+            
+        }
+    }
+    
+}
 
 extension BenefitViewController {
     func getBenefitMainData() {
@@ -392,11 +405,12 @@ extension BenefitViewController {
                 userBenefitData = benefitMainData
             }
             catch {
-                guard error is NetworkError else { return }
+                guard let error = error as? NetworkError else { return }
+                handlingError(error)
+
             }
         }
     }
-    
     func getBenefitEntireData() {
         Task {
             do {
@@ -404,7 +418,8 @@ extension BenefitViewController {
                 benefitEntireData = data
             }
             catch {
-                guard error is NetworkError else { return }
+                guard let error = error as? NetworkError else { return }
+                handlingError(error)
             }
         }
     }
@@ -416,7 +431,9 @@ extension BenefitViewController {
                 print(brandIdNum)
             }
             catch {
-                guard error is NetworkError else { return }
+                guard let error = error as? NetworkError else { return }
+                handlingError(error)
+
             }
         }
     }
@@ -430,3 +447,4 @@ extension BenefitViewController: NextButtonTapProtocol {
     
     
 }
+

--- a/NaverPay/Scenes/Benefit/ViewControllers/BenefitViewController.swift
+++ b/NaverPay/Scenes/Benefit/ViewControllers/BenefitViewController.swift
@@ -379,8 +379,11 @@ extension BenefitViewController: ItemSelectedProtocol {
     func getButtonState(isLiked: Bool, brandId: Int) {
         if isLiked {
             postLikedBrand(brandIdNum: brandId, post: .post)
+            LHToast.show(message: "좋아요")
         } else {
             postLikedBrand(brandIdNum: brandId, post: .delete)
+            LHToast.show(message: "싫어요")
+
         }
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- #53

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
토스트 메세지 구현
------------------
### 토스트 메세지 사용 방법
#### 1. 토스트메세지를 사용하는 곳에서 아래 함수를 호출하면 됩니다
```swift
NPToast.show(message: "토스트메세지입니다")
```

#### 2. 사용예시
예를들어 로그인버튼을 누르면 test토스트 메세지를 띄우는 경우에 아래와같이 코드를 작성하면 됩니다
```swift
@objc func buttonTapped() {
    NPToast.show(message: "토스트메세지입니다")
}
```

### 토스트메세지 코드 설명
#### 1. 아래코드는 현재 window의 subView들중에서 UIView를 상속받지않는 view들을 걸러주고 superview에서 제거시켜 toastview가 superview에서 보일수있도록 설정하는 코드입니다
```swift
guard let window = UIWindow.current else { return }
window.subviews
    .filter { $0 is LHToastView }
    .forEach { $0.removeFromSuperview() }
window.addSubview(toastView)
```

#### 2. fadeIn 함수와 fadeOut 함수를 이용해서 toastMessageView를 띄웁니다
```swift
fadeIn(completion: {
    DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
        fadeOut(completion: {
            completion?()
        })
    }
})

func fadeIn(completion: (() -> Void)? = nil) {
    toastView.alpha = 0
    UIView.animate(withDuration: 0.5) {
        toastView.alpha = 1
    } completion: { _ in
        completion?()
    }
}

func fadeOut(completion: (() -> Void)? = nil) {
    toastView.alpha = 1
    UIView.animate(withDuration: 0.5) {
        toastView.alpha = 0
    } completion: { _ in
        toastView.removeFromSuperview()
        completion?()
    }
}
```

에러 핸들링
----------
- 서버에서 주는 statusCode는 400과 404가 있었습니다. 그래서 400과 404가 들어올 때, 그 에러의 message를 띄우기로 했습니다.
1. 우선 에러들의 enum을 만들었습니다.
```swift
    case clientError(message: String)
```

2. 그리고 decode하고 난 후, 400이나 404가 들어오면 메세지를 담은 에러를 throw 했습니다.
```swift
 guard let model = try? JSONDecoder().decode(BaseResponse<T>.self, from: data) else {
            throw NetworkError.jsonDecodingError
        }

        
        
        if model.status == 400 || model.status == 401 {
            throw NetworkError.clientError(message: model.message)
        }
```

3. 그리고 뷰컨에서 캐치를 하여 따로 핸들링 에러 메서드를 만들어 토스트로 띄우게 했습니다.
```swift
extension BenefitViewController {
    func handlingError(_ error: NetworkError) {
        switch error {
        case .clientError(let message):
            NPToast.show(message: "\(message)")
        default:
            NPToast.show(message: error.description)
            
        }
    }
    
}

extension BenefitViewController {
    func getBenefitMainData() {
        Task {
            do {
                let benefitMainData = try await BenefitService.shared.getBenefitMainData()
                userBenefitData = benefitMainData
            }
            catch {
                guard let error = error as? NetworkError else { return }
                handlingError(error)

            }
        }
```



## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|성공|![Simulator Screen Recording - iPhone 13 mini - 2023-12-01 at 16 00 48](https://github.com/SOPT-33RD-APP-NAVERPAY/NaverPay-iOS/assets/70939232/58be60e5-824c-4f09-a604-be3cc4800ffc)|


## 📟 관련 이슈
- Resolved: #53
